### PR TITLE
Fix scoped test execution

### DIFF
--- a/src/Script Includes/snd_Spoke.js
+++ b/src/Script Includes/snd_Spoke.js
@@ -2268,7 +2268,7 @@ snd_Spoke.executeFromScripts = function (glide_record, script_field) {
       fn;
 
   var script = 'try {\n' +
-      'var $ = new snd_Spoke();\n' +
+      'var $ = new global.snd_Spoke();\n' +
       '$.updateEnv(this);\n\n';
 
   if (glide_record.hasNext()) {
@@ -2279,11 +2279,11 @@ snd_Spoke.executeFromScripts = function (glide_record, script_field) {
                   'sys_updated_on: "' + glide_record.getValue('sys_updated_on') + '", ' +
                   'sys_id: "' + glide_record.getValue('sys_id') + '" ' +
                 '});\n';
-      script += 'snd_Spoke.EXECUTE_LINE = ' + script.split('\n').length + ' + 1;\n';
+      script += 'global.snd_Spoke.EXECUTE_LINE = ' + script.split('\n').length + ' + 1;\n';
       script += 'describe("' + glide_record.getDisplayValue() + '", function () { \n';
       script += 'try {';
       script += glide_record.getValue(script_field) + '\n\n';
-      script += '} catch (e) { fail(snd_Spoke.exceptionFormatter.formatMessage(e)); }';
+      script += '} catch (e) { fail(global.snd_Spoke.exceptionFormatter.formatMessage(e)); }';
       script += '});\n';
     }
     script += '$.execute();';


### PR DESCRIPTION
Couldn't run a scoped test without these changes. Looks like these were originally in the code in earlier versions, but were removed for some reason.

Here's log info about error:

```
java.lang.SecurityException: snd_Spoke undefined, maybe missing global qualifier
Caused by error in sys_script_include.null at line 2

1: try {
==> 2: var $ = new snd_Spoke();
3: $.updateEnv(this);
4: 
5: $.reporter.storeDetails({$display: "t1_spec", api_name: "x_9210_t1.t1_spec", sys_updated_on: "2016-11-11 16:15:19", sys_id: "b1f25d950f4322009412cd8ce1050e08" });
```